### PR TITLE
Support branch names that include slashes.

### DIFF
--- a/lib/StashHandler.js
+++ b/lib/StashHandler.js
@@ -251,7 +251,7 @@ StashHandler.prototype.pushHandler = function(event, cb) {
     repo: repository.slug,
     repo_id: repository.id,
     // refId: refs/heads/feature
-    branch: payload.refChanges[0].refId.split('/')[2],
+    branch: payload.refChanges[0].refId.replace('refs/heads/','').replace('/','-'),
     branch_html_url: repoHtmlUrl + `/commits?until=${encodeURIComponent(payload.refChanges[0].refId)}`,
     sha: commitHash,
     commit_url: repoHtmlUrl + '/commits/' + commitHash,


### PR DESCRIPTION
The second replace could be removed if `branch` supports slashes.